### PR TITLE
Add Python 3.9 to test environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{36,37,38}-test{,-alldeps,-devdeps}{,-cov}
-    py{36,37,38}-test-numpy{116,117,118}
-    py{36,37,38}-test-astropy{30,40,lts}
+    py{37,38,39}-test{,-alldeps,-devdeps}{,-cov}
+    py{37,38,39}-test-numpy{116,117,118}
+    py{37,38,39}-test-astropy{30,40,lts}
     build_docs
     linkcheck
     codestyle


### PR DESCRIPTION
This PR add Python 3.9 to the test environment and remove the Python 3.6 version. Python 3.6 will only be support until Dec, 2021 (see e.g. https://azure.microsoft.com/en-us/updates/community-support-for-python-36-is-ending-on-23-december-2021/), so it's maybe better to not support it anymore.