### PR TITLE
Add pybind 11 struct example and tests

### DIFF
--- a/pylira/__init__.py
+++ b/pylira/__init__.py
@@ -5,6 +5,6 @@
 # ----------------------------------------------------------------------------
 from ._astropy_init import *   # noqa
 # ----------------------------------------------------------------------------
-from _lira import add, subtract
+from _lira import add, subtract, Pet
 
-__all__ = ["add", "subtract"]
+__all__ = ["add", "subtract", "Pet"]

--- a/pylira/src/lira.cpp
+++ b/pylira/src/lira.cpp
@@ -1,13 +1,20 @@
 #include <pybind11/pybind11.h>
 
-#define STRINGIFY(x) #x
-#define MACRO_STRINGIFY(x) STRINGIFY(x)
 
 int add(int i, int j) {
     return i + j;
 }
 
+struct Pet {
+    Pet(const std::string &name) : name(name) { }
+    void setName(const std::string &name_) { name = name_; }
+    const std::string &getName() const { return name; }
+
+    std::string name;
+};
+
 namespace py = pybind11;
+
 
 PYBIND11_MODULE(_lira, m) {
     m.doc() = R"pbdoc(
@@ -35,9 +42,8 @@ PYBIND11_MODULE(_lira, m) {
         Some other explanation about the subtract function.
     )pbdoc");
 
-#ifdef VERSION_INFO
-    m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
-#else
-    m.attr("__version__") = "dev";
-#endif
-}
+   py::class_<Pet>(m, "Pet")
+        .def(py::init<const std::string &>())
+        .def("setName", &Pet::setName)
+        .def("getName", &Pet::getName);
+};

--- a/pylira/tests/test_core.py
+++ b/pylira/tests/test_core.py
@@ -15,4 +15,3 @@ def test_c_extension_struct():
 
     p.setName("Charly")
     assert p.getName() == "Charly"
-

--- a/pylira/tests/test_core.py
+++ b/pylira/tests/test_core.py
@@ -1,10 +1,18 @@
-def test_import():
-    import pylira
+import pylira
 
+
+def test_import_name():
     assert pylira.__name__ == "pylira"
 
 
-def test_c_extension():
-    import pylira as p
+def test_c_extension_function():
+    assert pylira.add(3, 4) == 7
 
-    assert p.add(3, 4) == 7
+
+def test_c_extension_struct():
+    p = pylira.Pet("Molly")
+    assert p.getName() == "Molly"
+
+    p.setName("Charly")
+    assert p.getName() == "Charly"
+


### PR DESCRIPTION
This PR adds an example for binding a struct. It is mostly taken from the pybin11 documentation here: https://pybind11.readthedocs.io/en/latest/classes.html#creating-bindings-for-a-custom-type It also adds a test to verify it works correctly.