### PR TITLE
Add minimal numpy example using pybind vectorize

### DIFF
--- a/pylira/src/lira.cpp
+++ b/pylira/src/lira.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
 
 
 int add(int i, int j) {
@@ -30,7 +31,7 @@ PYBIND11_MODULE(_lira, m) {
            subtract
     )pbdoc";
 
-    m.def("add", &add, R"pbdoc(
+    m.def("add", py::vectorize(add), R"pbdoc(
         Add two numbers
 
         Some other explanation about the add function.

--- a/pylira/tests/test_core.py
+++ b/pylira/tests/test_core.py
@@ -1,3 +1,5 @@
+import numpy as np
+from numpy.testing import assert_allclose
 import pylira
 
 
@@ -7,6 +9,15 @@ def test_import_name():
 
 def test_c_extension_function():
     assert pylira.add(3, 4) == 7
+
+
+def test_c_extension_function_numpy():
+    a = np.array([1, 2, 3])
+    b = np.array([4, 3, 2])
+    result = pylira.add(a, b)
+
+    assert result.dtype == "int32"
+    assert_allclose(result, 5)
 
 
 def test_c_extension_struct():


### PR DESCRIPTION
This PR adds a minimal example using pybind's `py::vectorize` to vectorise the `add` function and make it work with Numpy arrays. This not the way we want the wrapper to work in the end, but this examples still makes sure that the build system and test works correctly with Numpy