### PR TITLE
Add minimal numpy wrapper example #2

### DIFF
--- a/pylira/__init__.py
+++ b/pylira/__init__.py
@@ -5,6 +5,6 @@
 # ----------------------------------------------------------------------------
 from ._astropy_init import *   # noqa
 # ----------------------------------------------------------------------------
-from _lira import add, subtract, Pet
+from _lira import add, subtract, Pet, add_arrays
 
-__all__ = ["add", "subtract", "Pet"]
+__all__ = ["add", "subtract", "Pet", "add_arrays"]

--- a/pylira/src/lira.cpp
+++ b/pylira/src/lira.cpp
@@ -1,6 +1,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 
+namespace py = pybind11;
 
 int add(int i, int j) {
     return i + j;
@@ -14,7 +15,30 @@ struct Pet {
     std::string name;
 };
 
-namespace py = pybind11;
+
+py::array_t<double> add_arrays(py::array_t<double> input1, py::array_t<double> input2) {
+    py::buffer_info buf1 = input1.request(), buf2 = input2.request();
+
+    if (buf1.ndim != 1 || buf2.ndim != 1)
+        throw std::runtime_error("Number of dimensions must be one");
+
+    if (buf1.size != buf2.size)
+        throw std::runtime_error("Input shapes must match");
+
+    /* No pointer is passed, so NumPy will allocate the buffer */
+    auto result = py::array_t<double>(buf1.size);
+
+    py::buffer_info buf3 = result.request();
+
+    double *ptr1 = static_cast<double *>(buf1.ptr);
+    double *ptr2 = static_cast<double *>(buf2.ptr);
+    double *ptr3 = static_cast<double *>(buf3.ptr);
+
+    for (size_t idx = 0; idx < buf1.shape[0]; idx++)
+        ptr3[idx] = ptr1[idx] + ptr2[idx];
+
+    return result;
+}
 
 
 PYBIND11_MODULE(_lira, m) {
@@ -43,8 +67,10 @@ PYBIND11_MODULE(_lira, m) {
         Some other explanation about the subtract function.
     )pbdoc");
 
-   py::class_<Pet>(m, "Pet")
+    py::class_<Pet>(m, "Pet")
         .def(py::init<const std::string &>())
         .def("setName", &Pet::setName)
         .def("getName", &Pet::getName);
+
+    m.def("add_arrays", &add_arrays, "Add two NumPy arrays");
 };

--- a/pylira/tests/test_core.py
+++ b/pylira/tests/test_core.py
@@ -11,12 +11,22 @@ def test_c_extension_function():
     assert pylira.add(3, 4) == 7
 
 
-def test_c_extension_function_numpy():
+def test_c_extension_function_numpy_vectorize():
     a = np.array([1, 2, 3])
     b = np.array([4, 3, 2])
     result = pylira.add(a, b)
 
     assert result.dtype == "int32"
+    assert_allclose(result, 5)
+
+
+def test_c_extension_function_numpy():
+    a = np.array([1, 2, 3])
+    b = np.array([4, 3, 2])
+    result = pylira.add_arrays(a, b)
+
+    # this casts the type on input
+    assert result.dtype == "float64"
     assert_allclose(result, 5)
 
 


### PR DESCRIPTION
This PR adds a second Numpy wrapper example, that make use of the buffer protocol for the wrapping. This is mostly taken from pybind11 documentation. It could be interesting to adapt this later to the [direct access method](https://pybind11.readthedocs.io/en/stable/advanced/pycpp/numpy.html#direct-access).