### PR TITLE
Split Python bindings from source code

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,3 +14,5 @@ prune docs/_build
 prune docs/api
 
 global-exclude *.pyc *.o
+
+graft pylira/src

--- a/pylira/src/lira.h
+++ b/pylira/src/lira.h
@@ -41,36 +41,3 @@ py::array_t<double> add_arrays(py::array_t<double> input1, py::array_t<double> i
 }
 
 
-PYBIND11_MODULE(_lira, m) {
-    m.doc() = R"pbdoc(
-        Pybind11 example plugin
-        -----------------------
-
-        .. currentmodule:: python_example
-
-        .. autosummary::
-           :toctree: _generate
-
-           add
-           subtract
-    )pbdoc";
-
-    m.def("add", py::vectorize(add), R"pbdoc(
-        Add two numbers
-
-        Some other explanation about the add function.
-    )pbdoc");
-
-    m.def("subtract", [](int i, int j) { return i - j; }, R"pbdoc(
-        Subtract two numbers
-
-        Some other explanation about the subtract function.
-    )pbdoc");
-
-    py::class_<Pet>(m, "Pet")
-        .def(py::init<const std::string &>())
-        .def("setName", &Pet::setName)
-        .def("getName", &Pet::getName);
-
-    m.def("add_arrays", &add_arrays, "Add two NumPy arrays");
-};

--- a/pylira/src/lirabind.cpp
+++ b/pylira/src/lirabind.cpp
@@ -1,0 +1,35 @@
+#include "lira.h"
+
+PYBIND11_MODULE(_lira, m) {
+    m.doc() = R"pbdoc(
+        Pybind11 example plugin
+        -----------------------
+
+        .. currentmodule:: python_example
+
+        .. autosummary::
+           :toctree: _generate
+
+           add
+           subtract
+    )pbdoc";
+
+    m.def("add", py::vectorize(add), R"pbdoc(
+        Add two numbers
+
+        Some other explanation about the add function.
+    )pbdoc");
+
+    m.def("subtract", [](int i, int j) { return i - j; }, R"pbdoc(
+        Subtract two numbers
+
+        Some other explanation about the subtract function.
+    )pbdoc");
+
+    py::class_<Pet>(m, "Pet")
+        .def(py::init<const std::string &>())
+        .def("setName", &Pet::setName)
+        .def("getName", &Pet::getName);
+
+    m.def("add_arrays", &add_arrays, "Add two NumPy arrays");
+};

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,8 @@ except Exception:
 ext_modules = [
     Pybind11Extension(
         name="_lira",
-        sources=["pylira/src/lira.cpp"],
+        sources=["pylira/src/lirabind.cpp"],
+        include_dirs=["pylira/src/",]
     ),
 ]
 


### PR DESCRIPTION
This PR splits the pybind11 bindings from the source code and adapts the build system accordingly.