### PR TITLE
Add parameter trace asserts

### DIFF
--- a/pylira/tests/test_core.py
+++ b/pylira/tests/test_core.py
@@ -6,6 +6,7 @@ from pylira.data import (
     disk_source_gauss_psf,
     gauss_and_point_sources_gauss_psf
 )
+from pylira.utils.io import read_parameter_trace_file
 from pylira import LIRADeconvolver
 
 
@@ -26,7 +27,7 @@ def test_lira_deconvolver():
     assert_allclose(deconvolve.alpha_init, [1., 2., 3.])
 
 
-def test_lira_deconvolver_run_point_source():
+def test_lira_deconvolver_run_point_source(tmpdir):
     data = point_source_gauss_psf()
     data["flux_init"] = data["flux"]
 
@@ -35,14 +36,19 @@ def test_lira_deconvolver_run_point_source():
     deconvolve = LIRADeconvolver(
         alpha_init=alpha_init,
         n_iter_max=100,
-        n_burn_in=10
+        n_burn_in=10,
+        filename_out=tmpdir / "image-trace.txt",
+        filename_out_par=tmpdir / "parameter-trace.txt",
     )
     result = deconvolve.run(data=data)
 
     assert(result[16][16] > 700)
 
+    trace_par = read_parameter_trace_file(tmpdir / "parameter-trace.txt")
+    assert_allclose(trace_par["smoothingParam0"][0], 0.043435)
 
-def test_lira_deconvolver_run_disk_source():
+
+def test_lira_deconvolver_run_disk_source(tmpdir):
     data = disk_source_gauss_psf()
     data["flux_init"] = data["flux"]
 
@@ -51,14 +57,19 @@ def test_lira_deconvolver_run_disk_source():
     deconvolve = LIRADeconvolver(
         alpha_init=alpha_init,
         n_iter_max=100,
-        n_burn_in=10
+        n_burn_in=10,
+        filename_out=tmpdir / "image-trace.txt",
+        filename_out_par=tmpdir / "parameter-trace.txt",
     )
     result = deconvolve.run(data=data)
 
     assert(result[16][16] > 0.2)
 
+    trace_par = read_parameter_trace_file(tmpdir / "parameter-trace.txt")
+    assert_allclose(trace_par["smoothingParam0"][0], 0.164671)
 
-def test_lira_deconvolver_run_gauss_source():
+
+def test_lira_deconvolver_run_gauss_source(tmpdir):
     data = gauss_and_point_sources_gauss_psf()
     data["flux_init"] = data["flux"]
 
@@ -67,8 +78,13 @@ def test_lira_deconvolver_run_gauss_source():
     deconvolve = LIRADeconvolver(
         alpha_init=alpha_init,
         n_iter_max=100,
-        n_burn_in=10
+        n_burn_in=10,
+        filename_out=tmpdir / "image-trace.txt",
+        filename_out_par=tmpdir / "parameter-trace.txt",
     )
     result = deconvolve.run(data=data)
 
     assert(result[16][16] > 0.2)
+
+    trace_par = read_parameter_trace_file(tmpdir / "parameter-trace.txt")
+    assert_allclose(trace_par["smoothingParam0"][0], 0.236136)

--- a/pylira/tests/test_core.py
+++ b/pylira/tests/test_core.py
@@ -45,7 +45,7 @@ def test_lira_deconvolver_run_point_source(tmpdir):
     assert(result[16][16] > 700)
 
     trace_par = read_parameter_trace_file(tmpdir / "parameter-trace.txt")
-    assert_allclose(trace_par["smoothingParam0"][0], 0.043435)
+    assert trace_par["smoothingParam0"][-1] > 0
 
 
 def test_lira_deconvolver_run_disk_source(tmpdir):
@@ -66,7 +66,7 @@ def test_lira_deconvolver_run_disk_source(tmpdir):
     assert(result[16][16] > 0.2)
 
     trace_par = read_parameter_trace_file(tmpdir / "parameter-trace.txt")
-    assert_allclose(trace_par["smoothingParam0"][0], 0.164671)
+    assert trace_par["smoothingParam0"][-1] > 0
 
 
 def test_lira_deconvolver_run_gauss_source(tmpdir):
@@ -87,4 +87,4 @@ def test_lira_deconvolver_run_gauss_source(tmpdir):
     assert(result[16][16] > 0.2)
 
     trace_par = read_parameter_trace_file(tmpdir / "parameter-trace.txt")
-    assert_allclose(trace_par["smoothingParam0"][0], 0.236136)
+    assert trace_par["smoothingParam0"][-1] > 0


### PR DESCRIPTION
This PR adds asserts on the parameter trace of the current tests. However I noticed that currently the random number generation in R is not seeded. The results are not deterministic. For meaningful and reproducible testing we need to change this. @infinitron Any concrete suggestion how to achieve this? Probably we just introduce and additional seed integer that is passed down to the `image_analysis_R` method?