### PR TITLE
Expose fit background scale parameter

### DIFF
--- a/pylira/core.py
+++ b/pylira/core.py
@@ -119,6 +119,7 @@ class LIRADeconvolver:
             max_iter=self.n_iter_max,
             burn_in=self.n_burn_in,
             save_thin=self.save_thin,
+            fit_bkgscl=int(self.fit_background_scale),
             out_img_file=str(self.filename_out),
             out_param_file=str(self.filename_out_par),
             alpha_init=self.alpha_init,

--- a/pylira/src/lirabind.cpp
+++ b/pylira/src/lirabind.cpp
@@ -12,7 +12,7 @@ np_arr_d image_analysis(np_arr_d& t_obs, np_arr_d& t_start, np_arr_d& t_psf,
                         np_arr_d& t_expmap, np_arr_d& t_baseline,
                         const std::string& t_out_file, const std::string& t_param_file,
                         np_arr_d& t_alpha_init, int t_max_iter, int t_burn_in,
-                        int t_save_thin, bool t_fit_bkgscl, double t_ms_ttlcnt_pr,
+                        int t_save_thin, int t_fit_bkgscl, double t_ms_ttlcnt_pr,
                         double t_ms_ttlcnt_exp, double t_ms_al_kap1,
                         double t_ms_al_kap2, double t_ms_al_kap3) {
   auto obs_buf = t_obs.request();
@@ -51,7 +51,7 @@ np_arr_d image_analysis(np_arr_d& t_obs, np_arr_d& t_start, np_arr_d& t_psf,
   image_analysis_R(dummy, post_mean_arr, obs_arr, start_arr, psf_arr, expmap_arr,
                    baseline_arr, &out_file_name, &param_file_name, &t_max_iter,
                    &t_burn_in, &true_int, &true_int, &nrows_obs, &ncols_obs, &nrows_psf,
-                   &ncols_psf, &true_int, &true_int, alpha_int_arr, &nvals_alpha,
+                   &ncols_psf, &true_int, &t_fit_bkgscl, alpha_int_arr, &nvals_alpha,
                    &t_ms_ttlcnt_pr, &t_ms_ttlcnt_exp, &t_ms_al_kap2, &t_ms_al_kap1,
                    &t_ms_al_kap3);
 

--- a/pylira/tests/test_core.py
+++ b/pylira/tests/test_core.py
@@ -39,6 +39,7 @@ def test_lira_deconvolver_run_point_source(tmpdir):
         n_burn_in=10,
         filename_out=tmpdir / "image-trace.txt",
         filename_out_par=tmpdir / "parameter-trace.txt",
+        fit_background_scale=True
     )
     result = deconvolve.run(data=data)
 
@@ -60,6 +61,7 @@ def test_lira_deconvolver_run_disk_source(tmpdir):
         n_burn_in=10,
         filename_out=tmpdir / "image-trace.txt",
         filename_out_par=tmpdir / "parameter-trace.txt",
+        fit_background_scale=True
     )
     result = deconvolve.run(data=data)
 
@@ -81,6 +83,7 @@ def test_lira_deconvolver_run_gauss_source(tmpdir):
         n_burn_in=10,
         filename_out=tmpdir / "image-trace.txt",
         filename_out_par=tmpdir / "parameter-trace.txt",
+        fit_background_scale=True
     )
     result = deconvolve.run(data=data)
 


### PR DESCRIPTION
This PR adds the `fit_bkgscl` parameters to the `image_analysis` binding methods and exposes it to the `LIRADeconvolver` class.