### PR TITLE
Add trace table to Deconvolver result

### DIFF
--- a/pylira/core.py
+++ b/pylira/core.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import numpy as np
+from pylira.utils.io import read_parameter_trace_file
 from . import image_analysis
 
 DTYPE_DEFAULT = np.float64
@@ -125,7 +126,7 @@ class LIRADeconvolver:
         data = {name: arr.astype(DTYPE_DEFAULT) for name, arr in data.items()}
         self._check_input_sizes(data["counts"])
 
-        result = image_analysis(
+        posterior_mean = image_analysis(
             observed_im=data["counts"],
             start_im=data["flux_init"],
             psf_im=data["psf"],
@@ -144,4 +145,11 @@ class LIRADeconvolver:
             ms_al_kap2=self.ms_al_kap2,
             ms_al_kap3=self.ms_al_kap3,
         )
-        return result
+
+        parameter_trace = read_parameter_trace_file(self.filename_out_par)
+        config = self.to_dict()
+        parameter_trace.meta.update(config)
+        return {
+            "posterior-mean": posterior_mean,
+            "parameter-trace": parameter_trace,
+        }

--- a/pylira/core.py
+++ b/pylira/core.py
@@ -120,8 +120,9 @@ class LIRADeconvolver:
 
         Returns
         -------
-        result : `~numpy.ndarray`
-            Mean posterior.
+        result : dict
+            Result dictionary containing "posterior-mean" (`~numpy.ndarray`)
+            and "parameter-trace" (`~astropy.table.Table`).
         """
         data = {name: arr.astype(DTYPE_DEFAULT) for name, arr in data.items()}
         self._check_input_sizes(data["counts"])

--- a/pylira/core.py
+++ b/pylira/core.py
@@ -94,6 +94,21 @@ class LIRADeconvolver:
                 f"Number of elements in alpha_init must be {np.log2(obs_shape)}.\
                      Size given: {self.alpha_init.shape[0]} ")
 
+    def to_dict(self):
+        """Convert deconvolver configuration to dict, with simple data types.
+
+        Returns
+        -------
+        data : dict
+            Parameter dict.
+        """
+        data = {}
+        data.update(self.__dict__)
+        data["alpha_init"] = self.alpha_init.tolist()
+        data["filename_out"] = str(self.filename_out)
+        data["filename_out_par"] = str(self.filename_out_par)
+        return data
+
     def run(self, data):
         """Run the algorithm
 

--- a/pylira/tests/test_core.py
+++ b/pylira/tests/test_core.py
@@ -6,7 +6,6 @@ from pylira.data import (
     disk_source_gauss_psf,
     gauss_and_point_sources_gauss_psf
 )
-from pylira.utils.io import read_parameter_trace_file
 from pylira import LIRADeconvolver
 
 
@@ -30,7 +29,7 @@ def test_lira_deconvolver():
 
     assert_allclose(config["alpha_init"], [1, 2, 3])
     assert config["filename_out"] == "output.txt"
-    
+
 
 def test_lira_deconvolver_run_point_source(tmpdir):
     data = point_source_gauss_psf()
@@ -48,10 +47,13 @@ def test_lira_deconvolver_run_point_source(tmpdir):
     )
     result = deconvolve.run(data=data)
 
-    assert(result[16][16] > 700)
+    posterior_mean = result["posterior-mean"]
 
-    trace_par = read_parameter_trace_file(tmpdir / "parameter-trace.txt")
+    assert(posterior_mean[16][16] > 700)
+
+    trace_par = result["parameter-trace"]
     assert trace_par["smoothingParam0"][-1] > 0
+    assert "alpha_init" in trace_par.meta
 
 
 def test_lira_deconvolver_run_disk_source(tmpdir):
@@ -69,11 +71,13 @@ def test_lira_deconvolver_run_disk_source(tmpdir):
         fit_background_scale=True
     )
     result = deconvolve.run(data=data)
+    posterior_mean = result["posterior-mean"]
 
-    assert(result[16][16] > 0.2)
+    assert(posterior_mean[16][16] > 0.2)
 
-    trace_par = read_parameter_trace_file(tmpdir / "parameter-trace.txt")
+    trace_par = result["parameter-trace"]
     assert trace_par["smoothingParam0"][-1] > 0
+    assert "alpha_init" in trace_par.meta
 
 
 def test_lira_deconvolver_run_gauss_source(tmpdir):
@@ -91,8 +95,10 @@ def test_lira_deconvolver_run_gauss_source(tmpdir):
         fit_background_scale=True
     )
     result = deconvolve.run(data=data)
+    posterior_mean = result["posterior-mean"]
 
-    assert(result[16][16] > 0.2)
+    assert(posterior_mean[16][16] > 0.2)
 
-    trace_par = read_parameter_trace_file(tmpdir / "parameter-trace.txt")
+    trace_par = result["parameter-trace"]
     assert trace_par["smoothingParam0"][-1] > 0
+    assert "alpha_init" in trace_par.meta

--- a/pylira/tests/test_core.py
+++ b/pylira/tests/test_core.py
@@ -26,6 +26,11 @@ def test_lira_deconvolver():
     assert deconvolve.alpha_init.dtype == np.float64
     assert_allclose(deconvolve.alpha_init, [1., 2., 3.])
 
+    config = deconvolve.to_dict()
+
+    assert_allclose(config["alpha_init"], [1, 2, 3])
+    assert config["filename_out"] == "output.txt"
+    
 
 def test_lira_deconvolver_run_point_source(tmpdir):
     data = point_source_gauss_psf()

--- a/pylira/utils/plot.py
+++ b/pylira/utils/plot.py
@@ -1,7 +1,11 @@
 from itertools import zip_longest
 import numpy as np
 
-__all__ = ["plot_example_dataset", "plot_parameter_traces", "plot_parameter_distributions"]
+__all__ = [
+    "plot_example_dataset",
+    "plot_parameter_traces",
+    "plot_parameter_distributions",
+]
 
 
 def plot_example_dataset(data, figsize=(12, 7), **kwargs):
@@ -56,7 +60,9 @@ def plot_parameter_traces(parameter_trace, figsize=(16, 16), ncols=3, **kwargs):
     nrows = (len(table.colnames) // ncols) + 1
 
     fig, axes = plt.subplots(
-        ncols=ncols, nrows=nrows, figsize=figsize,
+        ncols=ncols,
+        nrows=nrows,
+        figsize=figsize,
     )
 
     n_burn_in = table.meta.get("n_burn_in", 0)
@@ -69,17 +75,33 @@ def plot_parameter_traces(parameter_trace, figsize=(16, 16), ncols=3, **kwargs):
             ax.set_visible(False)
             continue
 
-        ax.plot(idx[burn_in], parameter_trace[name][burn_in], alpha=0.3, label="Burn in",  **kwargs)
+        ax.plot(
+            idx[burn_in],
+            parameter_trace[name][burn_in],
+            alpha=0.3,
+            label="Burn in",
+            **kwargs
+        )
         ax.plot(idx[valid], parameter_trace[name][valid], label="Valid", **kwargs)
         ax.set_title(name.title())
         ax.set_xlabel("Number of Iterations")
 
         mean = np.mean(parameter_trace[name][valid])
-        ax.hlines(mean, n_burn_in, len(idx), color="tab:orange", zorder=10, label="Mean")
+        ax.hlines(
+            mean, n_burn_in, len(idx), color="tab:orange", zorder=10, label="Mean"
+        )
 
         std = np.std(parameter_trace[name][valid])
         y1, y2 = mean - std, mean + std
-        ax.fill_between(idx[valid], y1, y2, color="tab:orange", alpha=0.2, zorder=9, label="1 $\sigma$ Std. Deviation")
+        ax.fill_between(
+            idx[valid],
+            y1,
+            y2,
+            color="tab:orange",
+            alpha=0.2,
+            zorder=9,
+            label=r"1 $\sigma$ Std. Deviation",
+        )
 
         if name == "logPost":
             ax.legend()
@@ -109,14 +131,18 @@ def plot_parameter_distributions(parameter_trace, figsize=(16, 16), ncols=3, **k
     import matplotlib.pyplot as plt
 
     table = parameter_trace.copy()
-    table.remove_columns(["iteration", "stepSize", "cycleSpinRow", "cycleSpinCol", "logPost"])
+    table.remove_columns(
+        ["iteration", "stepSize", "cycleSpinRow", "cycleSpinCol", "logPost"]
+    )
 
     n_burn_in = table.meta.get("n_burn_in", 0)
 
     nrows = (len(table.colnames) // ncols) + 1
 
     fig, axes = plt.subplots(
-        ncols=ncols, nrows=nrows, figsize=figsize,
+        ncols=ncols,
+        nrows=nrows,
+        figsize=figsize,
     )
 
     kwargs.setdefault("color", "tab:blue")
@@ -137,7 +163,9 @@ def plot_parameter_distributions(parameter_trace, figsize=(16, 16), ncols=3, **k
 
         column_burn_in = parameter_trace[name][:n_burn_in]
         is_finite = np.isfinite(column_burn_in)
-        n_vals_burn_in, _, _ = ax.hist(column_burn_in[is_finite], alpha=0.3, label="Burn in", **kwargs)
+        n_vals_burn_in, _, _ = ax.hist(
+            column_burn_in[is_finite], alpha=0.3, label="Burn in", **kwargs
+        )
 
         ax.set_title(name.title())
         ax.set_xlabel("Number of Iterations")
@@ -148,7 +176,15 @@ def plot_parameter_distributions(parameter_trace, figsize=(16, 16), ncols=3, **k
 
         std = np.std(column)
         x1, x2 = mean - std, mean + std
-        ax.fill_betweenx(np.linspace(0, y_max, 10), x1, x2, color="tab:orange", alpha=0.2, zorder=9, label="1 $\sigma$ Std. Deviation")
+        ax.fill_betweenx(
+            np.linspace(0, y_max, 10),
+            x1,
+            x2,
+            color="tab:orange",
+            alpha=0.2,
+            zorder=9,
+            label=r"1 $\sigma$ Std. Deviation",
+        )
 
         if not has_legend:
             ax.legend()

--- a/pylira/utils/plot.py
+++ b/pylira/utils/plot.py
@@ -52,20 +52,37 @@ def plot_parameter_traces(parameter_trace, figsize=(16, 16), ncols=3, **kwargs):
     table = parameter_trace.copy()
     table.remove_columns(["iteration", "stepSize", "cycleSpinRow", "cycleSpinCol"])
 
+    kwargs.setdefault("color", "tab:blue")
     nrows = (len(table.colnames) // ncols) + 1
 
     fig, axes = plt.subplots(
         ncols=ncols, nrows=nrows, figsize=figsize,
     )
 
+    n_burn_in = table.meta.get("n_burn_in", 0)
+    burn_in = slice(0, n_burn_in)
+    valid = slice(n_burn_in, -1)
+    idx = np.arange(len(table))
+
     for name, ax in zip_longest(table.colnames, axes.flat):
         if name is None:
             ax.set_visible(False)
             continue
 
-        ax.plot(parameter_trace[name], **kwargs)
+        ax.plot(idx[burn_in], parameter_trace[name][burn_in], alpha=0.3, label="Burn in",  **kwargs)
+        ax.plot(idx[valid], parameter_trace[name][valid], label="Valid", **kwargs)
         ax.set_title(name.title())
         ax.set_xlabel("Number of Iterations")
+
+        mean = np.mean(parameter_trace[name][valid])
+        ax.hlines(mean, n_burn_in, len(idx), color="tab:orange", zorder=10, label="Mean")
+
+        std = np.std(parameter_trace[name][valid])
+        y1, y2 = mean - std, mean + std
+        ax.fill_between(idx[valid], y1, y2, color="tab:orange", alpha=0.2, zorder=9, label="1 $\sigma$ Std. Deviation")
+
+        if name == "logPost":
+            ax.legend()
 
     return axes
 
@@ -94,24 +111,47 @@ def plot_parameter_distributions(parameter_trace, figsize=(16, 16), ncols=3, **k
     table = parameter_trace.copy()
     table.remove_columns(["iteration", "stepSize", "cycleSpinRow", "cycleSpinCol", "logPost"])
 
+    n_burn_in = table.meta.get("n_burn_in", 0)
+
     nrows = (len(table.colnames) // ncols) + 1
 
     fig, axes = plt.subplots(
         ncols=ncols, nrows=nrows, figsize=figsize,
     )
 
+    kwargs.setdefault("color", "tab:blue")
+
     kwargs.setdefault("density", True)
     kwargs.setdefault("bins", int(np.sqrt(len(table))))
+
+    has_legend = False
 
     for name, ax in zip_longest(table.colnames, axes.flat):
         if name is None:
             ax.set_visible(False)
             continue
 
-        column = parameter_trace[name]
+        column = parameter_trace[name][n_burn_in:]
         is_finite = np.isfinite(column)
-        ax.hist(column[is_finite], **kwargs)
+        n_vals, bins, _ = ax.hist(column[is_finite], label="Valid", **kwargs)
+
+        column_burn_in = parameter_trace[name][:n_burn_in]
+        is_finite = np.isfinite(column_burn_in)
+        n_vals_burn_in, _, _ = ax.hist(column_burn_in[is_finite], alpha=0.3, label="Burn in", **kwargs)
+
         ax.set_title(name.title())
         ax.set_xlabel("Number of Iterations")
+
+        y_max = np.max([n_vals, n_vals_burn_in])
+        mean = np.mean(column)
+        ax.vlines(mean, 0, y_max, color="tab:orange", zorder=10, label="Mean")
+
+        std = np.std(column)
+        x1, x2 = mean - std, mean + std
+        ax.fill_betweenx(np.linspace(0, y_max, 10), x1, x2, color="tab:orange", alpha=0.2, zorder=9, label="1 $\sigma$ Std. Deviation")
+
+        if not has_legend:
+            ax.legend()
+            has_legend = True
 
     return axes


### PR DESCRIPTION
This PR adds the trace table to the result of the `LIRADeconvolver` class, this is very convenient for interactive usage. I also added the configuration meta date to the table.