### PR TITLE
Implement LIRADeconvolverResult object

### DIFF
--- a/pylira/core.py
+++ b/pylira/core.py
@@ -121,9 +121,8 @@ class LIRADeconvolver:
 
         Returns
         -------
-        result : dict
-            Result dictionary containing "posterior-mean" (`~numpy.ndarray`)
-            and "parameter-trace" (`~astropy.table.Table`).
+        result : `LIRADeconvolverResult`
+            Result object.
         """
         data = {name: arr.astype(DTYPE_DEFAULT) for name, arr in data.items()}
         self._check_input_sizes(data["counts"])
@@ -191,10 +190,12 @@ class LIRADeconvolverResult:
     @property
     def posterior_mean(self):
         """Posterior mean (`~numpy.ndarray`)"""
-        if self._posterior_mean is None:
-            self._posterior_mean = np.nanmean(self.image_trace[self.n_burn_in:], axis=0)
-
         return self._posterior_mean
+
+    @property
+    def posterior_mean_from_trace(self):
+        """Posterior mean computed from trace(`~numpy.ndarray`)"""
+        return np.nanmean(self.image_trace[self.n_burn_in:], axis=0)
 
     @property
     def image_trace(self):

--- a/pylira/core.py
+++ b/pylira/core.py
@@ -6,7 +6,7 @@ from .utils.io import read_parameter_trace_file, read_image_trace_file
 
 DTYPE_DEFAULT = np.float64
 
-__all__ = ["LIRADeconvolver"]
+__all__ = ["LIRADeconvolver", "LIRADeconvolverResult"]
 
 
 class LIRADeconvolver:

--- a/pylira/core.py
+++ b/pylira/core.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 import numpy as np
-from astropy.table import Table
 from . import image_analysis
 from .utils.io import read_parameter_trace_file, read_image_trace_file
-from .utils.plot import plot_parameter_traces, plot_parameter_distributions
 
 
 DTYPE_DEFAULT = np.float64

--- a/pylira/tests/test_core.py
+++ b/pylira/tests/test_core.py
@@ -52,6 +52,8 @@ def test_lira_deconvolver_run_point_source(tmpdir):
     assert result.parameter_trace["smoothingParam0"][-1] > 0
     assert "alpha_init" in result.config
 
+    assert_allclose(result.posterior_mean, result.posterior_mean_from_trace, atol=1e-2)
+
 
 def test_lira_deconvolver_run_disk_source(tmpdir):
     data = disk_source_gauss_psf()
@@ -74,6 +76,8 @@ def test_lira_deconvolver_run_disk_source(tmpdir):
     assert result.parameter_trace["smoothingParam0"][-1] > 0
     assert "alpha_init" in result.config
 
+    assert_allclose(result.posterior_mean, result.posterior_mean_from_trace, atol=1e-2)
+
 
 def test_lira_deconvolver_run_gauss_source(tmpdir):
     data = gauss_and_point_sources_gauss_psf()
@@ -95,3 +99,5 @@ def test_lira_deconvolver_run_gauss_source(tmpdir):
 
     assert result.parameter_trace["smoothingParam0"][-1] > 0
     assert "alpha_init" in result.config
+
+    assert_allclose(result.posterior_mean, result.posterior_mean_from_trace, atol=1e-2)

--- a/pylira/tests/test_core.py
+++ b/pylira/tests/test_core.py
@@ -47,13 +47,10 @@ def test_lira_deconvolver_run_point_source(tmpdir):
     )
     result = deconvolve.run(data=data)
 
-    posterior_mean = result["posterior-mean"]
+    assert(result.posterior_mean[16][16] > 700)
 
-    assert(posterior_mean[16][16] > 700)
-
-    trace_par = result["parameter-trace"]
-    assert trace_par["smoothingParam0"][-1] > 0
-    assert "alpha_init" in trace_par.meta
+    assert result.parameter_trace["smoothingParam0"][-1] > 0
+    assert "alpha_init" in result.config
 
 
 def test_lira_deconvolver_run_disk_source(tmpdir):

--- a/pylira/tests/test_core.py
+++ b/pylira/tests/test_core.py
@@ -71,13 +71,11 @@ def test_lira_deconvolver_run_disk_source(tmpdir):
         fit_background_scale=True
     )
     result = deconvolve.run(data=data)
-    posterior_mean = result["posterior-mean"]
 
-    assert(posterior_mean[16][16] > 0.2)
+    assert(result.posterior_mean[16][16] > 0.2)
 
-    trace_par = result["parameter-trace"]
-    assert trace_par["smoothingParam0"][-1] > 0
-    assert "alpha_init" in trace_par.meta
+    assert result.parameter_trace["smoothingParam0"][-1] > 0
+    assert "alpha_init" in result.config
 
 
 def test_lira_deconvolver_run_gauss_source(tmpdir):
@@ -95,10 +93,8 @@ def test_lira_deconvolver_run_gauss_source(tmpdir):
         fit_background_scale=True
     )
     result = deconvolve.run(data=data)
-    posterior_mean = result["posterior-mean"]
 
-    assert(posterior_mean[16][16] > 0.2)
+    assert(result.posterior_mean[16][16] > 0.2)
 
-    trace_par = result["parameter-trace"]
-    assert trace_par["smoothingParam0"][-1] > 0
-    assert "alpha_init" in trace_par.meta
+    assert result.parameter_trace["smoothingParam0"][-1] > 0
+    assert "alpha_init" in result.config


### PR DESCRIPTION
This PR implements a `LIRADeconvolverResult` which provide convenience access to the results, such as posterior mean, parameter and image trace. In future PRs I'll add serialisation, plotting and combination of result objects.