### PR TITLE
Implement result FITS serialization

### DIFF
--- a/pylira/core.py
+++ b/pylira/core.py
@@ -238,4 +238,3 @@ class LIRADeconvolverResult:
 
         writer = IO_FORMATS[format]
         writer(result=self, filename=filename, overwrite=overwrite)
-

--- a/pylira/core.py
+++ b/pylira/core.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import numpy as np
 from . import image_analysis
-from .utils.io import read_parameter_trace_file, read_image_trace_file
+from .utils.io import read_parameter_trace_file, read_image_trace_file, IO_FORMATS
 
 
 DTYPE_DEFAULT = np.float64
@@ -218,3 +218,24 @@ class LIRADeconvolverResult:
             self._parameter_trace.meta.update(self.config)
 
         return self._parameter_trace
+
+    def write(self, filename, overwrite=False, format="fits"):
+        """Write result fo file
+
+        Parameters
+        ----------
+        filename : str or `Path`
+            Output filename
+        overwrite : bool
+            Overwrite file.
+        format : {"fits"}
+            Format to use.
+        """
+        filename = Path(filename)
+
+        if format not in IO_FORMATS:
+            raise ValueError(f"Not a valid format '{format}', choose from {list(IO_FORMATS)}")
+
+        writer = IO_FORMATS[format]
+        writer(result=self, filename=filename, overwrite=overwrite)
+

--- a/pylira/utils/io.py
+++ b/pylira/utils/io.py
@@ -1,5 +1,6 @@
 import numpy as np
 from astropy.table import Table
+from astropy.io import fits
 
 
 def read_parameter_trace_file(filename):
@@ -41,3 +42,39 @@ def read_image_trace_file(filename):
     n_iter = shape_y // shape_x
 
     return data.reshape((n_iter, shape_x, shape_x))
+
+
+def write_to_fits_hdulist(result, filename, overwrite):
+    """Convert LIRA result to list of FITS hdus.
+
+    Parameters
+    ----------
+    result : `LIRADeconvolverResult`
+        Deconvolution result.
+    filename : `Path`
+        Output filename
+    overwrite : bool
+        Overwrite file.
+    """
+    hdulist = fits.HDUList()
+
+    if result.wcs:
+        header = result.wcs.to_header()
+    else:
+        header = None
+
+    primary_hdu = fits.PrimaryHDU(header=header, data=result.posterior_mean)
+    parameter_trace_hdu = fits.BinTableHDU(result.parameter_trace)
+    image_trace_hdu = fits.ImageHDU(header=header, data=result.image_trace)
+
+    hdulist["POSTERIOR_MEAN"] = primary_hdu
+    hdulist["PARAMETER_TRACE"] = parameter_trace_hdu
+    hdulist["IMAGE_TRACE"] = image_trace_hdu
+
+    with filename.open("w") as f:
+        hdulist.writeto(f, overwrite=overwrite)
+
+
+IO_FORMATS = {
+    "fits": write_to_fits_hdulist
+}


### PR DESCRIPTION
This PR adds `LIRADeconvolverResult.write` methods to be able to serialize the result including posterior mean, parameter trace and image trace. 