### PR TITLE
Implement result FITS serialization read

### DIFF
--- a/pylira/__init__.py
+++ b/pylira/__init__.py
@@ -6,6 +6,6 @@
 from ._astropy_init import *   # noqa
 # ----------------------------------------------------------------------------
 from _lira import image_analysis # noqa
-from .core import LIRADeconvolver  # noqa
+from .core import LIRADeconvolver, LIRADeconvolverResult  # noqa
 
-__all__ = ["LIRADeconvolver"]
+__all__ = ["LIRADeconvolver", "LIRADeconvolverResult"]

--- a/pylira/core.py
+++ b/pylira/core.py
@@ -173,9 +173,11 @@ class LIRADeconvolverResult:
     posterior_mean : `~numpy.ndarray`
         Posterior mean
     parameter_trace : `~astropy.table.Table` or dict
-        Parameter trace
+        Parameter trace. If a dict is provided it triggers the lazy loading.
+        The dict must contain the argument to `read_parameter_trace_file`.
     image_trace : `~astropy.table.Table` or dict
-        Image trace
+        Image trace. If a dict is provided it triggers the lazy loading.
+        The dict must contain the argument to `read_image_trace_file`.
     wcs : `~astropy.wcs.WCS`
         World coordinate transform object
     """

--- a/pylira/core.py
+++ b/pylira/core.py
@@ -2,7 +2,12 @@ from pathlib import Path
 import numpy as np
 from astropy.table import Table
 from . import image_analysis
-from .utils.io import read_parameter_trace_file, read_image_trace_file, IO_FORMATS_WRITE, IO_FORMATS_READ
+from .utils.io import (
+    read_parameter_trace_file,
+    read_image_trace_file,
+    IO_FORMATS_WRITE,
+    IO_FORMATS_READ,
+)
 
 
 DTYPE_DEFAULT = np.float64
@@ -174,7 +179,14 @@ class LIRADeconvolverResult:
     wcs : `~astropy.wcs.WCS`
         World coordinate transform object
     """
-    def __init__(self, config, posterior_mean=None,  parameter_trace=None, image_trace=None, wcs=None):
+    def __init__(
+            self,
+            config,
+            posterior_mean=None,
+            parameter_trace=None,
+            image_trace=None,
+            wcs=None
+    ):
         self._config = config
         self._posterior_mean = posterior_mean
         self._wcs = wcs

--- a/pylira/tests/test_core.py
+++ b/pylira/tests/test_core.py
@@ -7,7 +7,7 @@ from pylira.data import (
     disk_source_gauss_psf,
     gauss_and_point_sources_gauss_psf
 )
-from pylira import LIRADeconvolver
+from pylira import LIRADeconvolver, LIRADeconvolverResult
 
 
 @pytest.fixture(scope="session")
@@ -48,7 +48,7 @@ def test_lira_deconvolver():
     config = deconvolve.to_dict()
 
     assert_allclose(config["alpha_init"], [1, 2, 3])
-    assert config["filename_out"] == "output.txt"
+    assert not config["fit_background_scale"]
 
 
 def test_lira_deconvolver_run_point_source(lira_result):
@@ -110,3 +110,13 @@ def test_lira_deconvolver_run_gauss_source(tmpdir):
 def test_lira_deconvolver_result_write(tmpdir, lira_result):
     filename = tmpdir / "test.fits.gz"
     lira_result.write(filename)
+
+
+def test_lira_deconvolver_result_read(tmpdir, lira_result):
+    filename = tmpdir / "test.fits.gz"
+    lira_result.write(filename)
+
+    new_result = LIRADeconvolverResult.read(filename)
+
+    assert_allclose(lira_result.config["alpha_init"], new_result.config["alpha_init"])
+    assert_allclose(lira_result.posterior_mean, new_result.posterior_mean)

--- a/pylira/utils/io.py
+++ b/pylira/utils/io.py
@@ -4,7 +4,7 @@ from astropy.io import fits
 from astropy.wcs import WCS
 
 
-def read_parameter_trace_file(filename, format):
+def read_parameter_trace_file(filename, format="ascii"):
     """Read LIRA parameter output file
 
     Parameters
@@ -25,7 +25,7 @@ def read_parameter_trace_file(filename, format):
     return table
 
 
-def read_image_trace_file(filename, format):
+def read_image_trace_file(filename, format="ascii"):
     """Read LIRA image trace file
 
     Parameters


### PR DESCRIPTION
This PR adds a `LIRADeconvolverResult.read` method to be able to read a result back from FITS.