### PR TITLE
Implement pixel trace plotting

### DIFF
--- a/pylira/core.py
+++ b/pylira/core.py
@@ -8,7 +8,7 @@ from .utils.io import (
     IO_FORMATS_WRITE,
     IO_FORMATS_READ,
 )
-from .utils.plot import plot_parameter_traces, plot_parameter_distributions
+from .utils.plot import plot_parameter_traces, plot_parameter_distributions, plot_pixel_trace
 
 
 DTYPE_DEFAULT = np.float64
@@ -253,11 +253,50 @@ class LIRADeconvolverResult:
 
         return self._parameter_trace
 
+    def plot_pixel_trace(self, center_pix=None, figsize=(16, 6)):
+        """Plot pixel traces in a given region
+
+        Parameters
+        ----------
+        center_pix : tuple of int
+             Pixel indices, order is (x, y).
+        figsize : tuple of float
+            Figure size
+
+        """
+        import matplotlib.pyplot as plt
+        from matplotlib.patches import Circle
+
+        fig = plt.figure(figsize=figsize)
+
+        if center_pix is None:
+            # choose center as default
+            center_pix = tuple(np.array(self.posterior_mean.shape) // 2)
+
+        data = self.posterior_mean_from_trace
+
+        ax_image = plt.subplot(1, 2, 1, projection=self.wcs)
+        im = ax_image.imshow(data, origin="lower")
+        fig.colorbar(im, ax=ax_image, label="Posterior Mean")
+
+        artist = Circle(center_pix, radius=1, color="w", fc="None")
+        ax_image.add_artist(artist)
+
+        ax_trace = plt.subplot(1, 2, 2, projection=self.wcs)
+        plot_pixel_trace(
+            ax=ax_trace,
+            image_trace=self.image_trace,
+            config=self.config,
+            center_pix=center_pix,
+        )
+
     def plot_posterior_mean(self, from_image_trace=False, **kwargs):
         """Plot posteriror mean
 
         Parameters
         ----------
+        from_image_trace : bool
+            Recompute posterior from image trace.
         **kwargs : dict
             Keyword arguments forwarded to `~matplotlib.pyplot.imshow`
         """

--- a/pylira/utils/plot.py
+++ b/pylira/utils/plot.py
@@ -5,6 +5,7 @@ __all__ = [
     "plot_example_dataset",
     "plot_parameter_traces",
     "plot_parameter_distributions",
+    "plot_pixel_trace",
 ]
 
 
@@ -247,10 +248,18 @@ def plot_pixel_trace(image_trace, center_pix, ax=None, config=None, **kwargs):
         Image traces array
     center_pix : tuple of int
         Pixel indices center, order is (x, y).
+    ax : `~matplotlib.pyplot.Axes`
+        Plotting axes
     config : dict
         Configuration dictionary
     **kwargs : dict
         Keyword arguments passed to `~matplotlib.pyplot.plot`
+
+    Returns
+    -------
+    ax : `~matplotlib.pyplot.Axes`
+        Plotting axes
+
     """
     import matplotlib.pyplot as plt
 

--- a/pylira/utils/plot.py
+++ b/pylira/utils/plot.py
@@ -37,6 +37,54 @@ def get_grid_figsize(width, ncols, nrows):
     return width, height
 
 
+def plot_trace(ax, idx, trace, n_burn_in, **kwargs):
+    """Plot a single parameter trace
+
+    Parameters
+    ----------
+    ax : `~matplotlib.pyplot.Axes`
+        Plot axes
+    idx : `~numpy.ndarray`
+        Iteration
+    trace : `~numpy.ndarray`
+        Trace to plot
+    n_burn_in : int
+        Number of burn in iterations
+    **kwargs : dict
+        Keyword arguments passed to `~matplotlib.pyplot.plot`
+
+    """
+    burn_in = slice(0, n_burn_in)
+    valid = slice(n_burn_in, -1)
+
+    ax.plot(
+        idx[burn_in],
+        trace[burn_in],
+        alpha=0.3,
+        label="Burn in",
+        **kwargs
+    )
+    ax.plot(idx[valid], trace[valid], label="Valid", **kwargs)
+    ax.set_xlabel("Number of Iterations")
+
+    mean = np.mean(trace[valid])
+    ax.hlines(
+        mean, n_burn_in, len(idx), color="tab:orange", zorder=10, label="Mean"
+    )
+
+    std = np.std(trace[valid])
+    y1, y2 = mean - std, mean + std
+    ax.fill_between(
+        idx[valid],
+        y1,
+        y2,
+        color="tab:orange",
+        alpha=0.2,
+        zorder=9,
+        label=r"1 $\sigma$ Std. Deviation",
+    )
+
+
 def plot_parameter_traces(parameter_trace, config=None, figsize=None, ncols=3, **kwargs):
     """Plot parameters traces
 

--- a/pylira/utils/plot.py
+++ b/pylira/utils/plot.py
@@ -215,3 +215,22 @@ def plot_parameter_distributions(parameter_trace, config=None, figsize=None, nco
             has_legend = True
 
     return axes
+
+
+def plot_pixel_traces_region(image_trace, center, radius=5, **kwargs):
+    """Plot pixel traces in a circular region, given a position and radius.
+
+    Parameters
+    ----------
+    image_trace : `~numpy.ndarray`
+        Image traces array
+    center : tuple of int
+        Pixel indices center
+    radius : float
+        Radius of the of the region in pixels.
+    **kwargs : dict
+        Keyword arguments passed to `~matplotlib.pyplot.plot`
+    """
+    pass
+
+

--- a/pylira/utils/plot.py
+++ b/pylira/utils/plot.py
@@ -217,20 +217,37 @@ def plot_parameter_distributions(parameter_trace, config=None, figsize=None, nco
     return axes
 
 
-def plot_pixel_traces_region(image_trace, center, radius=5, **kwargs):
+def plot_pixel_traces_region(image_trace, center_pix, radius_pix=5, posterior_mean=None, config=None, **kwargs):
     """Plot pixel traces in a circular region, given a position and radius.
 
     Parameters
     ----------
     image_trace : `~numpy.ndarray`
         Image traces array
-    center : tuple of int
+    config : dict
+        Configuration dictionary
+    center_pix : tuple of int
         Pixel indices center
-    radius : float
+    radius_pix : float
         Radius of the of the region in pixels.
+    posterior_mean : `~numpy.ndarray`
+        Posterior mean.
     **kwargs : dict
         Keyword arguments passed to `~matplotlib.pyplot.plot`
     """
-    pass
+    import matplotlib.pyplot as plt
+
+    if posterior_mean is None:
+        posterior_mean = np.nanmean(self.image_trace[self.n_burn_in:], axis=0)
+
+    y_idx, x_idx = np.meshgrid()
+    y_center, x_center = center_pix
+
+    offset = np.sqrt((y_center - y_idx) ** 2 + (x_center - x_idx) ** 2)
+    idx = np.where(offset < radius)
+
+    alpha = 1
+    kwargs.setdefault("alpha", alpha)
+    plt.plot(image_trace[idx, :], **kwargs)
 
 

--- a/pylira/utils/plot.py
+++ b/pylira/utils/plot.py
@@ -128,8 +128,6 @@ def plot_parameter_traces(parameter_trace, config=None, figsize=None, ncols=3, *
     )
 
     n_burn_in = config.get("n_burn_in", 0)
-    burn_in = slice(0, n_burn_in)
-    valid = slice(n_burn_in, -1)
     idx = np.arange(len(table))
 
     for name, ax in zip_longest(table.colnames, axes.flat):
@@ -137,34 +135,9 @@ def plot_parameter_traces(parameter_trace, config=None, figsize=None, ncols=3, *
             ax.set_visible(False)
             continue
 
-        ax.plot(
-            idx[burn_in],
-            parameter_trace[name][burn_in],
-            alpha=0.3,
-            label="Burn in",
-            **kwargs
-        )
-        ax.plot(idx[valid], parameter_trace[name][valid], label="Valid", **kwargs)
+        trace = parameter_trace[name]
+        plot_trace(ax=ax, trace=trace, idx=idx, n_burn_in=n_burn_in, **kwargs)
         ax.set_title(name.title())
-        ax.set_xlabel("Number of Iterations")
-
-        mean = np.mean(parameter_trace[name][valid])
-        ax.hlines(
-            mean, n_burn_in, len(idx), color="tab:orange", zorder=10, label="Mean"
-        )
-
-        std = np.std(parameter_trace[name][valid])
-        y1, y2 = mean - std, mean + std
-        ax.fill_between(
-            idx[valid],
-            y1,
-            y2,
-            color="tab:orange",
-            alpha=0.2,
-            zorder=9,
-            label=r"1 $\sigma$ Std. Deviation",
-        )
-
         if name == "logPost":
             ax.legend()
 

--- a/pylira/utils/plot.py
+++ b/pylira/utils/plot.py
@@ -238,37 +238,38 @@ def plot_parameter_distributions(parameter_trace, config=None, figsize=None, nco
     return axes
 
 
-def plot_pixel_traces_region(image_trace, center_pix, radius_pix=5, posterior_mean=None, config=None, **kwargs):
+def plot_pixel_trace(image_trace, center_pix, ax=None, config=None, **kwargs):
     """Plot pixel traces in a circular region, given a position and radius.
 
     Parameters
     ----------
     image_trace : `~numpy.ndarray`
         Image traces array
+    center_pix : tuple of int
+        Pixel indices center, order is (x, y).
     config : dict
         Configuration dictionary
-    center_pix : tuple of int
-        Pixel indices center
-    radius_pix : float
-        Radius of the of the region in pixels.
-    posterior_mean : `~numpy.ndarray`
-        Posterior mean.
     **kwargs : dict
         Keyword arguments passed to `~matplotlib.pyplot.plot`
     """
     import matplotlib.pyplot as plt
 
-    if posterior_mean is None:
-        posterior_mean = np.nanmean(self.image_trace[self.n_burn_in:], axis=0)
+    if config is None:
+        config = {}
 
-    y_idx, x_idx = np.meshgrid()
-    y_center, x_center = center_pix
+    if ax is None:
+        ax = plt.gca()
 
-    offset = np.sqrt((y_center - y_idx) ** 2 + (x_center - x_idx) ** 2)
-    idx = np.where(offset < radius)
+    n_iter, n_y, n_x = image_trace.shape
+    n_burn_in = config.get("n_burn_in", 0)
 
-    alpha = 1
-    kwargs.setdefault("alpha", alpha)
-    plt.plot(image_trace[idx, :], **kwargs)
+    idx = np.arange(n_iter)
 
+    trace = image_trace[(Ellipsis,) + center_pix[::-1]].T
 
+    kwargs.setdefault("color", "tab:blue")
+    plot_trace(ax=ax, trace=trace, idx=idx, n_burn_in=n_burn_in, **kwargs)
+    ax.set_title(f"Pixel trace for {center_pix}")
+    ax.set_xlabel("Number of Iterations")
+    ax.legend()
+    return ax

--- a/pylira/utils/tests/test_plot.py
+++ b/pylira/utils/tests/test_plot.py
@@ -1,6 +1,6 @@
 from astropy.utils.data import get_pkg_data_filename
-from pylira.utils.plot import plot_parameter_traces, plot_parameter_distributions
-from pylira.utils.io import read_parameter_trace_file
+from pylira.utils.plot import plot_parameter_traces, plot_parameter_distributions, plot_pixel_trace
+from pylira.utils.io import read_parameter_trace_file, read_image_trace_file
 
 
 def test_plot_parameter_traces():
@@ -17,3 +17,12 @@ def test_plot_parameter_distributions():
 
     axes = plot_parameter_distributions(table)
     assert axes.size == 9
+
+
+def test_plot_pixel_trace():
+    filename = get_pkg_data_filename("files/output.txt", package="pylira.data")
+
+    image_trace = read_image_trace_file(filename)
+
+    ax = plot_pixel_trace(image_trace=image_trace, center_pix=(3, 3), )
+    assert ax is not None


### PR DESCRIPTION
This PR implement a `plot_pixel_trace` helper method and exposes it as `LIRADeconvolverResult.plot_pixel_trace()`. I generates a plot like this:

![image](https://user-images.githubusercontent.com/3715928/143939493-f83fa52b-7acc-4702-a4a4-8ee5979a3dfc.png)

Which is very useful to check the convergence of the algorithm for a specific pixel.