### PR TITLE
Add LIRADeconvolver.__str__

### DIFF
--- a/pylira/core.py
+++ b/pylira/core.py
@@ -97,6 +97,18 @@ class LIRADeconvolver:
         self.filename_out = Path(filename_out)
         self.filename_out_par = Path(filename_out_par)
 
+    def __str__(self):
+        """String representation"""
+        cls_name = self.__class__.__name__
+        info = cls_name + "\n"
+        info += len(cls_name) * "-" + "\n\n"
+        data = self.to_dict()
+
+        for key, value in data.items():
+            info += f"\t{key:21s}: {value}\n"
+
+        return info.expandtabs(tabsize=4)
+
     def _check_input_sizes(self, obs_arr):
         obs_shape = obs_arr.shape[0]
         if obs_shape & (obs_shape - 1) != 0:

--- a/pylira/tests/test_core.py
+++ b/pylira/tests/test_core.py
@@ -50,6 +50,8 @@ def test_lira_deconvolver():
     assert_allclose(config["alpha_init"], [1, 2, 3])
     assert not config["fit_background_scale"]
 
+    assert "alpha_init" in str(deconvolve)
+
 
 def test_lira_deconvolver_run_point_source(lira_result):
     assert(lira_result.posterior_mean[16][16] > 700)

--- a/pylira/utils/plot.py
+++ b/pylira/utils/plot.py
@@ -8,6 +8,7 @@ __all__ = [
     "plot_parameter_traces",
     "plot_parameter_distributions",
     "plot_pixel_trace",
+    "plot_pixel_trace_neighbours",
 ]
 
 

--- a/pylira/utils/plot.py
+++ b/pylira/utils/plot.py
@@ -207,6 +207,7 @@ def plot_parameter_distributions(parameter_trace, config=None, figsize=None, nco
 
         column = parameter_trace[name][n_burn_in:]
         is_finite = np.isfinite(column)
+
         n_vals, bins, _ = ax.hist(column[is_finite], label="Valid", **kwargs)
 
         column_burn_in = parameter_trace[name][:n_burn_in]


### PR DESCRIPTION
This PR add a `__str__` method to print the current state of the `LIRADeconvolver` object.