### PR TITLE
Remove R.h dependency

### DIFF
--- a/pylira/src/lira.h
+++ b/pylira/src/lira.h
@@ -1,6 +1,4 @@
-#include <R_ext/Random.h>
 #define R_NO_REMAP 1
-#include <Rinternals.h>
 #define MATHLIB_STANDALONE 1
 #include <Rmath.h>
 #include <math.h>

--- a/pylira/src/lira.h
+++ b/pylira/src/lira.h
@@ -1,4 +1,3 @@
-#include <R.h>
 #include <R_ext/Random.h>
 #define R_NO_REMAP 1
 #include <Rinternals.h>
@@ -8,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdexcept>
 #include <time.h>
 #include <iostream>
 
@@ -221,7 +221,7 @@ int printf_d(const char*format,...){
 /***************************************************************/
 
 void c_error(char error_text[]) { /* Print an Error Message */
-  error("%s", error_text);
+  throw std::runtime_error(error_text);
 }
 
 /***************************************************************/

--- a/pylira/src/lira.h
+++ b/pylira/src/lira.h
@@ -1066,7 +1066,7 @@ void update_image_mrf(expmapType* expmap, cntType* src, mrfType* mrf,
     } /*j loop over src.img */
   }   /* i loop */
 
-  if (cont->em == 0) error("No code for MCMC fitting with MRF prior!!");
+  if (cont->em == 0) c_error("No code for MCMC fitting with MRF prior!!");
 
 } /*update_image_mrf */
 
@@ -1453,7 +1453,7 @@ void update_image_ml(expmapType* expmap, cntType* src, controlType* cont) {
       src->img[i][j] = exp(log(src->data[i][j]) - log(expmap->prod[i][j]));
     }
 
-  if (cont->em == 0) error("No code for MCMC fitting with flat prior (i.e, ML)!!");
+  if (cont->em == 0) c_error("No code for MCMC fitting with flat prior (i.e, ML)!!");
 
 } /* update_image_ml */
 


### PR DESCRIPTION
This PR removes the dependency on `R.h` and replaces the error handling by standard library error handling. 