### PR TITLE
Change to pydata sphinx theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,10 +104,10 @@ release = package.__version__
 # name of a builtin theme or the name of a custom theme in html_theme_path.
 #html_theme = None
 
-html_theme = "sphinx_rtd_theme"
+html_theme = "pydata_sphinx_theme"
 
 # Custom sidebar templates, maps document names to template names.
-# html_sidebars = {}
+html_sidebars = {}
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
@@ -121,6 +121,25 @@ html_logo = "pylira-logo.png"
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
 #html_last_updated_fmt = ''
+
+html_context = {
+    # "github_url": "https://github.com", # or your GitHub Enterprise interprise
+    "github_user": "astrostat",
+    "github_repo": "pylira",
+    "github_version": "main",
+    "doc_path": "docs",
+}
+
+html_theme_options = {
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/astrostat/pylira",
+            "icon": "fab fa-github-square",
+        },
+    ],
+    "use_edit_page_button": True,
+}
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,8 @@ Pylira is a Python package for Bayesian low-counts image reconstruction and anal
   :maxdepth: 2
 
   pylira/index.rst
-  pylira/data.rst
+  pylira/user.rst
+  pylira/api.rst
   pylira/developer.rst
   pylira/references.rst
   pylira/changelog.rst

--- a/docs/pylira/api.rst
+++ b/docs/pylira/api.rst
@@ -1,0 +1,5 @@
+*************
+Reference/API
+*************
+
+.. automodapi:: pylira

--- a/docs/pylira/changelog.rst
+++ b/docs/pylira/changelog.rst
@@ -1,5 +1,5 @@
-=========
-Changelog
-=========
+*************
+Release Notes
+*************
 
 Still empty...

--- a/docs/pylira/developer.rst
+++ b/docs/pylira/developer.rst
@@ -1,6 +1,6 @@
-***********************
-Developer Documentation
-***********************
+***********
+Development
+***********
 
 This is the developer documentation.
 

--- a/docs/pylira/index.rst
+++ b/docs/pylira/index.rst
@@ -1,6 +1,6 @@
-******************
-User Documentation
-******************
+***************
+Getting Started
+***************
 
 Pylira is a Python package for Bayesian low-counts image reconstruction and analysis.
 See e.g. [Esch2004]_, [Connors2007]_, [Connors2011]_ and [Stein2015]_.
@@ -14,7 +14,3 @@ Install directly from source using::
     cd pylira
     pip install -e .
 
-Reference/API
-=============
-
-.. automodapi:: pylira

--- a/docs/pylira/references.rst
+++ b/docs/pylira/references.rst
@@ -1,11 +1,8 @@
-.. _references:
-
-Glossary and references
-=======================
+**********
+References
+**********
 
 .. _glossary:
-
-
 
 Glossary
 --------
@@ -15,7 +12,7 @@ Glossary
     LIRA
       Lira stands for (L)ow-counts (I)mage (R)econstruction and (A)nalysis.
 
-.. _publications:
+.. _references:
 
 References
 ----------

--- a/docs/pylira/user.rst
+++ b/docs/pylira/user.rst
@@ -1,6 +1,6 @@
-****************
-Example Datasets
-****************
+**********
+User Guide
+**********
 
 Illustration of example datasets.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = pylira
 author = pylira developers
-author_email = 
+author_email =
 license = GNU GPL v3+
 license_file = licenses/LICENSE.rst
 url = http://docs.astropy.org/projects/package-template/
@@ -29,7 +29,7 @@ test =
     pytest-astropy
 docs =
     sphinx-astropy
-    sphinx_rtd_theme
+    pydata-sphinx-theme
 
 [options.package_data]
 pylira = data/*/*


### PR DESCRIPTION
This PR changes the documentation to https://pydata-sphinx-theme.readthedocs.io/en/latest/, which is the theme used by many bigger projects such as Numpy and matplotlib.