### PR TITLE
Add docs tutorials notebooks setup and first example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,15 @@ MANIFEST
 
 .hypothesis
 
+# Data files
+*.fits
+*.fits.gz
+*.txt
+
 # Sphinx
 docs/api
 docs/_build
+docs/tutorials/*.ipynb
 
 # Eclipse editor project files
 .project

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ MANIFEST
 # Sphinx
 docs/api
 docs/_build
-docs/tutorials/*.ipynb
+docs/pylira/user/tutorials/notebooks/*.ipynb
 
 # Eclipse editor project files
 .project

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -167,7 +167,17 @@ latex_documents = [('index', project + '.tex', project + u' Documentation',
 man_pages = [('index', project.lower(), project + u' Documentation',
               [author], 1)]
 
-extensions += ["matplotlib.sphinxext.plot_directive", "nbsphinx"]
+extensions += ["matplotlib.sphinxext.plot_directive", "nbsphinx", "sphinx_gallery.load_style"]
+
+
+nbsphinx_custom_formats = {
+    '.md': ['jupytext.reads', {'fmt': 'md'}],
+}
+
+nbsphinx_execute_arguments = [
+    "--InlineBackend.figure_formats={'svg'}",
+    "--InlineBackend.rc=figure.dpi=96",
+]
 
 # -- Options for the edit_on_github extension ---------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -167,7 +167,7 @@ latex_documents = [('index', project + '.tex', project + u' Documentation',
 man_pages = [('index', project.lower(), project + u' Documentation',
               [author], 1)]
 
-extensions += ["matplotlib.sphinxext.plot_directive"]
+extensions += ["matplotlib.sphinxext.plot_directive", "nbsphinx"]
 
 # -- Options for the edit_on_github extension ---------------------------------
 

--- a/docs/pylira/user/index.rst
+++ b/docs/pylira/user/index.rst
@@ -22,4 +22,5 @@ This is how to use ``pylira``:
    :hidden:
 
    data
+   tutorials/index
 

--- a/docs/pylira/user/tutorials/index.rst
+++ b/docs/pylira/user/tutorials/index.rst
@@ -1,0 +1,10 @@
+Tutorials
+=========
+
+This page shows tutorials.
+
+.. nbgallery::
+    :caption: This is a thumbnail gallery:
+    :name: rst-gallery
+
+    notebooks/point_source

--- a/docs/pylira/user/tutorials/notebooks/point_source.md
+++ b/docs/pylira/user/tutorials/notebooks/point_source.md
@@ -1,0 +1,82 @@
+---
+jupytext:
+  formats: ipynb,md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.3
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+# Simple Point Source Examples
+
+This tutorial shows you hwo to work with ``pylira`` using a simple simulated
+point source and Gaussian shaped point spread function.
+
+We first define the required imports:
+```{code-cell} ipython3
+%matplotlib inline
+import numpy as np
+import matplotlib.pyplot as plt
+
+from pylira.data import point_source_gauss_psf, gauss_and_point_sources_gauss_psf
+from pylira.utils.plot import plot_example_dataset
+from pylira import LIRADeconvolver, LIRADeconvolverResult
+```
+
+Then we can use 
+```{code-cell} ipython3
+data = point_source_gauss_psf()
+```
+
+```{code-cell} ipython3
+plot_example_dataset(data)
+```
+
+```{code-cell} ipython3
+data = gauss_and_point_sources_gauss_psf()
+data["flux_init"] = data["flux"]
+
+alpha_init = 0.1 * np.ones(np.log2(data["counts"].shape[0]).astype(int))
+
+dec = LIRADeconvolver(
+    alpha_init=alpha_init,
+    n_iter_max=3000,
+    n_burn_in=200,
+    ms_al_kap1=0,
+    ms_al_kap2=1000,
+    ms_al_kap3=10,
+    fit_background_scale=False,
+    random_state=np.random.RandomState(156)
+)
+```
+
+```{code-cell} ipython3
+%%time
+result = dec.run(data)
+result.write("test.fits.gz", overwrite=True)
+```
+
+```{code-cell} ipython3
+res = LIRADeconvolverResult.read("test.fits.gz")
+```
+
+```{code-cell} ipython3
+res.plot_posterior_mean(from_image_trace=True)
+```
+
+```{code-cell} ipython3
+res.plot_parameter_traces()
+```
+
+```{code-cell} ipython3
+res.plot_parameter_distributions()
+```
+
+```{code-cell} ipython3
+res.plot_pixel_traces_region(center_pix=(16, 16), radius_pix=4)
+```

--- a/docs/pylira/user/tutorials/notebooks/point_source.md
+++ b/docs/pylira/user/tutorials/notebooks/point_source.md
@@ -12,12 +12,13 @@ kernelspec:
   name: python3
 ---
 
-# Simple Point Source Examples
+# Simple Point Source Example
 
 This tutorial shows you hwo to work with ``pylira`` using a simple simulated
 point source and Gaussian shaped point spread function.
 
 We first define the required imports:
+
 ```{code-cell} ipython3
 %matplotlib inline
 import numpy as np
@@ -28,55 +29,79 @@ from pylira.utils.plot import plot_example_dataset
 from pylira import LIRADeconvolver, LIRADeconvolverResult
 ```
 
-Then we can use 
+Then we can use the method `point_source_gauss_psf` to get a pre-defined test
+dataset:
+
 ```{code-cell} ipython3
 data = point_source_gauss_psf()
+print(data.keys())
 ```
+
+The `data` variable is a `dict` containing the `counts`, `psf`, `exposure`,
+`background` and ground truth for `flux`. We ca illutrated the data using:
 
 ```{code-cell} ipython3
 plot_example_dataset(data)
 ```
 
-```{code-cell} ipython3
-data = gauss_and_point_sources_gauss_psf()
-data["flux_init"] = data["flux"]
+Next we define the `LIRADeconvolver` class, which holds the configuration
+the algorithm will be run with:
 
+```{code-cell} ipython3
 alpha_init = 0.1 * np.ones(np.log2(data["counts"].shape[0]).astype(int))
 
 dec = LIRADeconvolver(
     alpha_init=alpha_init,
     n_iter_max=3000,
     n_burn_in=200,
-    ms_al_kap1=0,
-    ms_al_kap2=1000,
-    ms_al_kap3=10,
     fit_background_scale=False,
-    random_state=np.random.RandomState(156)
 )
 ```
+
+We can print the instance to see the full configuration:
+
+```{code-cell} ipython3
+print(dec)
+```
+
+Now we have to define the initial guess for the flux and add it to the `data` dictionary.
+For this we use the reserved `"flux_init"`key:
+
+```{code-cell} ipython3
+data["flux_init"] = np.ones(data["counts"].shape)
+```
+
+Finally we can run the LIRA algorithm using `.run()`:
 
 ```{code-cell} ipython3
 %%time
 result = dec.run(data)
-result.write("test.fits.gz", overwrite=True)
+```
+
+To check the validity of the result we can plot the posterior mean:
+
+```{code-cell} ipython3
+result.plot_posterior_mean()
+```
+
+As well as the parameter traces:
+
+```{code-cell} ipython3
+result.plot_parameter_traces()
+```
+
+We can also plot the parameter distributions:
+
+```{code-cell} ipython3
+result.plot_parameter_distributions()
+```
+
+And pixel traces in a given region, to check for correlations with neighbouring pixels:
+
+```{code-cell} ipython3
+result.plot_pixel_traces_region(center_pix=(16, 16), radius_pix=2)
 ```
 
 ```{code-cell} ipython3
-res = LIRADeconvolverResult.read("test.fits.gz")
-```
 
-```{code-cell} ipython3
-res.plot_posterior_mean(from_image_trace=True)
-```
-
-```{code-cell} ipython3
-res.plot_parameter_traces()
-```
-
-```{code-cell} ipython3
-res.plot_parameter_distributions()
-```
-
-```{code-cell} ipython3
-res.plot_pixel_traces_region(center_pix=(16, 16), radius_pix=4)
 ```

--- a/docs/pylira/user/tutorials/notebooks/point_source.md
+++ b/docs/pylira/user/tutorials/notebooks/point_source.md
@@ -52,7 +52,7 @@ alpha_init = 0.1 * np.ones(np.log2(data["counts"].shape[0]).astype(int))
 
 dec = LIRADeconvolver(
     alpha_init=alpha_init,
-    n_iter_max=3000,
+    n_iter_max=1000,
     n_burn_in=200,
     fit_background_scale=False,
 )
@@ -81,6 +81,10 @@ result = dec.run(data)
 To check the validity of the result we can plot the posterior mean:
 
 ```{code-cell} ipython3
+---
+nbsphinx-thumbnail:
+  tooltip: "Learn how to use pylira on a simple point source example."
+---
 result.plot_posterior_mean()
 ```
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,8 @@ docs =
     pydata-sphinx-theme
     nbsphinx
     jupytext
+    ipykernel
+    sphinx-gallery
 
 [options.package_data]
 pylira = data/*/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,8 @@ test =
 docs =
     sphinx-astropy
     pydata-sphinx-theme
+    nbsphinx
+    jupytext
 
 [options.package_data]
 pylira = data/*/*


### PR DESCRIPTION
This PR adds the setup for including tutorial notebooks in the documentation as well as a first example running pylira on a simple point source example.