### PR TITLE
Add download link to tutorials

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -175,9 +175,17 @@ nbsphinx_custom_formats = {
 }
 
 nbsphinx_execute_arguments = [
-    "--InlineBackend.figure_formats={'svg'}",
+    "--InlineBackend.figure_formats={'png'}",
     "--InlineBackend.rc=figure.dpi=96",
 ]
+
+nbsphinx_epilog = """
+{% set docname = env.doc2path(env.docname, base=None) | replace('md', 'ipynb') | replace('pylira/user/tutorials/notebooks/', '')%}
+
+.. raw:: html
+
+    Notebook file for download: <a href="{{ docname|e }}">{{ docname|e }}</a>
+"""
 
 # -- Options for the edit_on_github extension ---------------------------------
 

--- a/docs/pylira/user/tutorials/notebooks/point_source.md
+++ b/docs/pylira/user/tutorials/notebooks/point_source.md
@@ -38,7 +38,7 @@ print(data.keys())
 ```
 
 The `data` variable is a `dict` containing the `counts`, `psf`, `exposure`,
-`background` and ground truth for `flux`. We ca illutrated the data using:
+`background` and ground truth for `flux`. We can illustrate the data using:
 
 ```{code-cell} ipython3
 plot_example_dataset(data)
@@ -83,7 +83,7 @@ To check the validity of the result we can plot the posterior mean:
 ```{code-cell} ipython3
 ---
 nbsphinx-thumbnail:
-  tooltip: "Learn how to use pylira on a simple point source example."
+  tooltip: Learn how to use pylira on a simple point source example.
 ---
 result.plot_posterior_mean()
 ```
@@ -104,8 +104,4 @@ And pixel traces in a given region, to check for correlations with neighbouring 
 
 ```{code-cell} ipython3
 result.plot_pixel_traces_region(center_pix=(16, 16), radius_pix=2)
-```
-
-```{code-cell} ipython3
-
 ```


### PR DESCRIPTION
This PR adds a download link to the end of the tutorial for downloading the `.ipynb` file.