### PR TITLE
Implement minimal fftconvolve 

### DIFF
--- a/docs/pylira/user/tutorials/notebooks/mcmc-deconvolution-intro.md
+++ b/docs/pylira/user/tutorials/notebooks/mcmc-deconvolution-intro.md
@@ -23,7 +23,7 @@ We start with defining the required imports:
 %matplotlib inline
 import matplotlib.pyplot as plt
 import numpy as np
-from astropy.convolution import convolve_fft
+from pylira.utils.convolution import fftconvolve
 from pylira.data import gauss_and_point_sources_gauss_psf
 from pylira.utils.plot import plot_example_dataset
 ```
@@ -46,7 +46,7 @@ We start by defining the model function to compute the predicted number of count
 ```{code-cell} ipython3
 def compute_npred(flux, psf, background, exposure):
     """Compute predicted number of counts"""
-    npred = convolve_fft((flux + background) * exposure, psf)
+    npred = fftconvolve((flux + background) * exposure, psf)
     # The FFT can produce noise, which could cause values to be negative
     npred = np.clip(npred, 0, np.inf)
     return npred

--- a/pylira/utils/convolution.py
+++ b/pylira/utils/convolution.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+
+__all__ = ["fftconvolve"]
+
+
+def _centered(arr, newshape):
+    # Return the center newshape portion of the array.
+    newshape = np.asarray(newshape)
+    currshape = np.array(arr.shape)
+    startind = (currshape - newshape) // 2
+    endind = startind + newshape
+    myslice = [slice(startind[k], endind[k]) for k in range(len(endind))]
+    return arr[tuple(myslice)]
+
+
+def fftconvolve(image, kernel):
+    """Convolve an image with a kernel
+
+    Minimal pure Numpy re-implementation of `scipy.signal.fftconvolve` jut to
+    avoid the dependency for now.
+
+    Parameters
+    ----------
+    image : `~numpy.ndarray`
+        Image array
+    kernel : `~numpy.ndarray`
+        Kernel array
+
+    Returns
+    -------
+    result : `~numpy.ndarray`
+        Convolution result.
+    """
+    shape_image = image.shape
+    shape_kernel = kernel.shape
+
+    shape = [shape_image[i] + shape_kernel[i] - 1 for i in range(image.ndim)]
+
+    ftimage = np.fft.rfft2(image, s=shape)
+    ftkernel = np.fft.rfft2(kernel, s=shape)
+    result = np.fft.irfft2(ftimage * ftkernel)
+    return _centered(result, image.shape)


### PR DESCRIPTION
This PR implements a minimal version of `scipy.signal.fftconvolve` to avoid the scipy dependency for now. The currently used `astropy.convolution.convolve_fft` introduces a bit to much overhead, as the method is call in the likelihood evaluation loop. 