### PR TITLE
Add random state to data simulation methods

### DIFF
--- a/pylira/core.py
+++ b/pylira/core.py
@@ -50,7 +50,7 @@ class LIRADeconvolver:
         Output filename
     filename_out_par: str or `Path`
         Parameter output filename
-    random_state : `~numpy.ransom.RandomState`
+    random_state : `~numpy.random.RandomState`
         Random state
 
     Examples

--- a/pylira/data/core.py
+++ b/pylira/data/core.py
@@ -15,6 +15,7 @@ def point_source_gauss_psf(
         sigma_psf=3,
         source_level=1000,
         background_level=2,
+        random_state=None,
 ):
     """Get point source with Gaussian PSF test data.
 
@@ -32,13 +33,16 @@ def point_source_gauss_psf(
         Total integrated counts of the source
     background_level : float
         Background level in counts / pixel.
+    random_state : `~numpy.random.RandomState`
+        Random state
 
     Returns
     -------
     data : dict of `~numpy.ndarray`
         Data dictionary
     """
-    np.random.seed(836)
+    if random_state is None:
+        random_state = np.random.RandomState(None)
 
     background = background_level * np.ones(shape)
     exposure = np.ones(shape)
@@ -49,7 +53,7 @@ def point_source_gauss_psf(
     psf = Gaussian2DKernel(sigma_psf, x_size=shape_psf[1], y_size=shape_psf[1])
     npred = background + convolve_fft(flux * exposure, psf)
 
-    counts = np.random.poisson(npred)
+    counts = random_state.poisson(npred)
     return {
         "counts": counts,
         "psf": psf.array,
@@ -66,6 +70,7 @@ def disk_source_gauss_psf(
         source_level=1000,
         source_radius=3,
         background_level=2,
+        random_state=None,
 ):
     """Get disk source with Gaussian PSF test data.
 
@@ -85,13 +90,16 @@ def disk_source_gauss_psf(
         Radius of the disk source
     background_level : float
         Background level in counts / pixel.
+    random_state : `~numpy.random.RandomState`
+        Random state
 
     Returns
     -------
     data : dict of `~numpy.ndarray`
         Data dictionary
     """
-    np.random.seed(836)
+    if random_state is None:
+        random_state = np.random.RandomState(None)
 
     background = background_level * np.ones(shape)
     exposure = np.ones(shape) + 0.5 * np.linspace(-1, 1, shape[0])
@@ -103,7 +111,7 @@ def disk_source_gauss_psf(
     psf = Gaussian2DKernel(sigma_psf, x_size=shape_psf[1], y_size=shape_psf[1])
     npred = convolve_fft((flux + background) * exposure, psf)
 
-    counts = np.random.poisson(npred)
+    counts = random_state.poisson(npred)
     return {
         "counts": counts,
         "psf": psf.array,
@@ -120,6 +128,7 @@ def gauss_and_point_sources_gauss_psf(
         source_level=1000,
         source_radius=2,
         background_level=2,
+        random_state=None,
 ):
     """Get data with a Gaussian source in the center and point sources of varying brightness
     of 100%, 30%, 10% and 3% of the Gaussian source.
@@ -140,13 +149,16 @@ def gauss_and_point_sources_gauss_psf(
         Radius of the disk source
     background_level : float
         Background level in counts / pixel.
+    random_state : `~numpy.random.RandomState`
+        Random state
 
     Returns
     -------
     data : dict of `~numpy.ndarray`
         Data dictionary
     """
-    np.random.seed(836)
+    if random_state is None:
+        random_state = np.random.RandomState(None)
 
     background = background_level * np.ones(shape)
     exposure = np.ones(shape) + 0.5 * np.linspace(-1, 1, shape[0]).reshape((-1, 1))
@@ -161,7 +173,7 @@ def gauss_and_point_sources_gauss_psf(
     psf = Gaussian2DKernel(sigma_psf, x_size=shape_psf[1], y_size=shape_psf[1])
     npred = convolve_fft((flux + background) * exposure, psf)
 
-    counts = np.random.poisson(npred)
+    counts = random_state.poisson(npred)
     return {
         "counts": counts,
         "psf": psf.array,

--- a/pylira/data/tests/test_core.py
+++ b/pylira/data/tests/test_core.py
@@ -1,4 +1,6 @@
+import numpy as np
 from numpy.testing import assert_allclose
+import pytest
 from pylira.data import (
     point_source_gauss_psf,
     disk_source_gauss_psf,
@@ -6,8 +8,13 @@ from pylira.data import (
 )
 
 
-def test_data_point_source_gauss_psf():
-    data = point_source_gauss_psf()
+@pytest.fixture()
+def random_state():
+    return np.random.RandomState(836)
+
+
+def test_data_point_source_gauss_psf(random_state):
+    data = point_source_gauss_psf(random_state=random_state)
 
     assert_allclose(data["counts"][0][0], 2)
     assert_allclose(data["exposure"][0][0], 1)
@@ -16,8 +23,8 @@ def test_data_point_source_gauss_psf():
     assert_allclose(data["flux"][16][16], 1000, rtol=1e-5)
 
 
-def test_data_disk_source_gauss_psf():
-    data = disk_source_gauss_psf()
+def test_data_disk_source_gauss_psf(random_state):
+    data = disk_source_gauss_psf(random_state=random_state)
 
     assert_allclose(data["counts"][0][0], 1)
     assert_allclose(data["exposure"][0][0], 0.5)
@@ -26,8 +33,8 @@ def test_data_disk_source_gauss_psf():
     assert_allclose(data["flux"][16][16], 35.367765, rtol=1e-5)
 
 
-def test_data_gauss_and_point_sources_gauss_psf():
-    data = gauss_and_point_sources_gauss_psf()
+def test_data_gauss_and_point_sources_gauss_psf(random_state):
+    data = gauss_and_point_sources_gauss_psf(random_state=random_state)
 
     assert_allclose(data["counts"][0][0], 1)
     assert_allclose(data["exposure"][0][0], 0.5)

--- a/pylira/tests/test_core.py
+++ b/pylira/tests/test_core.py
@@ -12,7 +12,8 @@ from pylira import LIRADeconvolver, LIRADeconvolverResult
 
 @pytest.fixture(scope="session")
 def lira_result(tmpdir_factory):
-    data = point_source_gauss_psf()
+    random_state = np.random.RandomState(836)
+    data = point_source_gauss_psf(random_state=random_state)
     data["flux_init"] = data["flux"]
 
     alpha_init = 0.05 * np.ones(np.log2(data["counts"].shape[0]).astype(int))
@@ -131,7 +132,8 @@ def test_lira_deconvolver_run_disk_source(tmpdir):
 
 
 def test_lira_deconvolver_run_gauss_source(tmpdir):
-    data = gauss_and_point_sources_gauss_psf()
+    random_state = np.random.RandomState(836)
+    data = gauss_and_point_sources_gauss_psf(random_state=random_state)
     data["flux_init"] = data["flux"]
 
     alpha_init = 0.1 * np.ones(np.log2(data["counts"].shape[0]).astype(int))


### PR DESCRIPTION
This PR adds a `random_state` to the data simulation methods, to avoid the re-seed, which does not allow to simulated multiple datasets of the same type.